### PR TITLE
add fileName to options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Type: `Boolean`
 
 Determines whether a json file containing the tree structure should be emitted.
 
+#### options.fileName (default: `tree`)
+Type: `String`
+
+The base filename that the json tree structure should be emitted as.
+
 #### options.emitFiles (default: `false`)
 Type: `Boolean`
 

--- a/src/gulp-file-tree.js
+++ b/src/gulp-file-tree.js
@@ -14,12 +14,17 @@ var GulpFileTree = function (opts) {
 
 	opts = objectMerge({
 		emitTree: true,
+		fileName: 'tree',
 		transform: null,
 		emitFiles: false
 	}, opts || {});
 
 	if (opts.transform && typeof opts.transform !== 'function') {
 		throw new TypeError('\'transform\' option must be of type \'function\'');
+	}
+
+	if (opts.fileName && typeof opts.fileName !== 'string') {
+		throw new TypeError('\'fileName\' option must be of type \'string\'');
 	}
 
 	fileTree = new FileTree(opts.transform);
@@ -36,7 +41,7 @@ var GulpFileTree = function (opts) {
 		gft.push(new File({
 			cwd: '',
 			base: '',
-			path: 'tree.json',
+			path: opts.fileName + '.json',
 			contents: new Buffer(JSON.stringify(tree, null, '\t'))
 		}));
 	}

--- a/test/gulp-file-tree.spec.js
+++ b/test/gulp-file-tree.spec.js
@@ -83,6 +83,7 @@ describe('gulp-file-tree', function () {
 				emitTree: true,
 				transform: null,
 				emitFiles: true,
+				fileName: 'tree'
 			});
 
 			gft.on('data', function (file){
@@ -173,6 +174,50 @@ describe('gulp-file-tree', function () {
 
 				gulp.src('test/fixture/**/*')
 					.pipe(gft);
+			});
+		});
+
+		describe('fileName', function () {
+			it('emits only a single file with the same name as fileName option', function (done) {
+				var gft = gulpFileTree({
+					fileName: 'test'
+				}),
+					files = [];
+
+				gft.on('data', function (file) {
+					files.push(file);
+				});
+				gft.on('end', function () {
+					assert.equal(files[0].path, 'test.json');
+					done();
+				});
+
+				gulp.src('test/fixture/**/*')
+					.pipe(gft);
+			});
+
+			it('throws an error if fileName passed in is not of type \'string\'', function () {
+				assert.throws(function () {
+					var gft = gulpFileTree({
+							fileName: function(){}
+						});
+					gulp.src('test/fixture/**/*')
+						.pipe(gft);
+				}, TypeError, '\'fileName\' option must be of type \'string\'');
+				assert.throws(function () {
+					var gft = gulpFileTree({
+							fileName: 1245
+						});
+					gulp.src('test/fixture/**/*')
+						.pipe(gft);
+				}, TypeError, '\'fileName\' option must be of type \'string\'');
+				assert.throws(function () {
+					var gft = gulpFileTree({
+							fileName: {}
+						});
+					gulp.src('test/fixture/**/*')
+						.pipe(gft);
+				}, TypeError, '\'fileName\' option must be of type \'string\'');
 			});
 		});
 


### PR DESCRIPTION
I'm using this plugin in a few different tasks, for example building an images filetree, as well as an html filetree. I wanted an easy way to configure the output file, rather than rename the output afterwards.

I kept tree.json as the default filename, updated the readme, and added tests to spec.